### PR TITLE
Send content in chunks not from memory for InStream scan

### DIFF
--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
@@ -43,7 +43,7 @@ public final class InStreamScan implements VirusScanMode {
 	private final Logger logger = Logger.getLogger(InStreamScan.class);
 
 	private ContentReader dataReader;
-	private int chunkSize = 4096;
+	private int chunkSizeInBytes = 4096;
 	private int port;
 	private String host;
 	private int timeout;
@@ -150,7 +150,7 @@ public final class InStreamScan implements VirusScanMode {
 				logger.debug(getClass().getName() + "Send stream for  " + inputStream.available() + " bytes");
 			}
 
-			byte[] chunk = new byte[chunkSize];
+			byte[] chunk = new byte[chunkSizeInBytes];
 			int length = inputStream.read(chunk);
 			while (length >= 0) {
 				dataOutputStream.writeInt(length);
@@ -263,10 +263,10 @@ public final class InStreamScan implements VirusScanMode {
 	}
 
 	/**
-	 * @param chunkSize
+	 * @param chunkSizeInBytes
 	 */
-	public void setChunkSize(int chunkSize) {
-		this.chunkSize = chunkSize;
+	public void setChunkSizeInBytes(int chunkSizeInBytes) {
+		this.chunkSizeInBytes = chunkSizeInBytes;
 	}
 
 	/**

--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
@@ -19,11 +19,13 @@ package com.fegorsoft.alfresco.security.antivirus;
 import java.io.BufferedReader;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketException;
 
+import org.alfresco.service.cmr.repository.ContentReader;
 import org.alfresco.service.cmr.repository.NodeRef;
 import org.alfresco.service.cmr.repository.NodeService;
 import org.apache.log4j.Logger;
@@ -40,7 +42,7 @@ public final class InStreamScan implements VirusScanMode {
 
 	private final Logger logger = Logger.getLogger(InStreamScan.class);
 
-	private byte[] data;
+	private ContentReader dataReader;
 	private int chunkSize = 4096;
 	private int port;
 	private String host;
@@ -132,36 +134,38 @@ public final class InStreamScan implements VirusScanMode {
 
 		DataOutputStream dataOutputStream = null;
 		BufferedReader bufferedReader = null;
+		InputStream inputStream = dataReader.getContentInputStream();
 
 		String res = null;
 		try {
 			if (logger.isDebugEnabled()) {
 				logger.debug(getClass().getName() + "Send zINSTREAM");
 			}
-			
+
 			dataOutputStream = new DataOutputStream(socket.getOutputStream());
+			bufferedReader = new BufferedReader(new InputStreamReader(socket.getInputStream(), "ASCII"));
 			dataOutputStream.writeBytes("zINSTREAM\0");
 
 			if (logger.isDebugEnabled()) {
-				logger.debug(getClass().getName() + "Send stream for  " + data.length + " bytes");
+				logger.debug(getClass().getName() + "Send stream for  " + inputStream.available() + " bytes");
 			}
 
-			while (i < data.length) {
-				if (i + chunkSize >= data.length) {
-					chunkSize = data.length - i;
+			byte[] chunk = new byte[chunkSize];
+			int length = inputStream.read(chunk);
+			while (length >= 0) {
+				dataOutputStream.writeInt(length);
+				dataOutputStream.write(chunk, 0, length);
+				if (bufferedReader.ready()) {
+					res = bufferedReader.readLine();
+					throw new IOException(res);
 				}
-				dataOutputStream.writeInt(chunkSize);
-				dataOutputStream.write(data, i, chunkSize);
-				i += chunkSize;
+				length = inputStream.read(chunk);
 			}
 
 			dataOutputStream.writeInt(0);
 			dataOutputStream.write('\0');
 			dataOutputStream.flush();
 
-			bufferedReader = new BufferedReader(new InputStreamReader(
-					socket.getInputStream(), "ASCII"));
-				
 			res = bufferedReader.readLine();
 			
 			if (logger.isDebugEnabled()) {
@@ -174,6 +178,9 @@ public final class InStreamScan implements VirusScanMode {
 			
 			if (dataOutputStream != null)
 				dataOutputStream.close();
+
+			if (inputStream != null)
+				inputStream.close();
 			
 			if (socket != null)
 				socket.close();
@@ -249,10 +256,10 @@ public final class InStreamScan implements VirusScanMode {
 	}
 
 	/**
-	 * @param data
+	 * @param dataReader
 	 */
-	public void setData(byte[] data) {
-		this.data = data;
+	public void setDataReader(ContentReader dataReader) {
+		this.dataReader = dataReader;
 	}
 
 	/**

--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/services/AntivirusServiceImpl.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/services/AntivirusServiceImpl.java
@@ -187,7 +187,7 @@ public class AntivirusServiceImpl implements AntivirusService {
 						inStreamScan.setHost(inStreamHost);
 						inStreamScan.setPort(inStreamPort);
 						inStreamScan.setTimeout(inStreamTimeout);
-						inStreamScan.setData(contentReader.getContentString().getBytes());
+						inStreamScan.setDataReader(contentReader);
 						res = inStreamScan.scan(nodeRef);
 					}
 

--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/services/AntivirusServiceImpl.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/services/AntivirusServiceImpl.java
@@ -183,7 +183,7 @@ public class AntivirusServiceImpl implements AntivirusService {
 				else if (mode.toUpperCase().equals(VirusScanMode.ScanModeInStream)) {
 
 					try {
-						inStreamScan.setChunkSize(inStreamChunkSize);
+						inStreamScan.setChunkSizeInBytes(inStreamChunkSize);
 						inStreamScan.setHost(inStreamHost);
 						inStreamScan.setPort(inStreamPort);
 						inStreamScan.setTimeout(inStreamTimeout);


### PR DESCRIPTION
The current implementation uses a byte array to hold the file content, which can cause `java.lang.OutOfMemoryError: Java heap space` for larger files. This PR reads the data in chunks instead and also adds a check for early server responses while sending data (such as error messages when exceeding the configured size limit for the server).

[ALFREDOPS-828](https://xenitsupport.jira.com/browse/ALFREDOPS-828)