### PR TITLE
Fix size limit false positives

### DIFF
--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
@@ -101,7 +101,7 @@ public final class InStreamScan implements VirusScanMode {
 		try {
 			res = scan();
 		} catch (IOException e) {
-			e.printStackTrace();
+			logger.error("Error while scanning NodeRef: " + nodeRef, e);
 		}
 		return res;
 	}
@@ -186,10 +186,15 @@ public final class InStreamScan implements VirusScanMode {
 				socket.close();
 		}
 
+		res = res.trim();
+		if (res.startsWith("INSTREAM size limit exceeded")) {
+			throw new IOException(res);
+		}
+
 		/*
 		 * if is OK then not infected, else, infected...
 		 */
-		if (!res.trim().equals("stream: OK")) {
+		if (!res.equals("stream: OK")) {
 			result = 1;
 			addAspect();
 		}

--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
@@ -147,7 +147,7 @@ public final class InStreamScan implements VirusScanMode {
 			dataOutputStream.writeBytes("zINSTREAM\0");
 
 			if (logger.isDebugEnabled()) {
-				logger.debug(getClass().getName() + "Send stream for  " + inputStream.available() + " bytes");
+				logger.debug(getClass().getName() + "Send stream for " + dataReader.getSize() + " bytes");
 			}
 
 			byte[] chunk = new byte[chunkSizeInBytes];


### PR DESCRIPTION
Fixes false positives caused by files being just over the instream size limit. This case wasn't yet covered by checking for server response after sending each chunk. Also fixes the logging of the stream size.

