### PR TITLE
Improve handling of scan result string

### DIFF
--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
@@ -196,7 +196,7 @@ public final class InStreamScan implements VirusScanMode {
 		} else if (res.endsWith("FOUND")) {
 			result = 1;
 			addAspect();
-		} else if (res.endsWith("ERROR")) {
+		} else if (res.endsWith("ERROR")) { // explicit else kept for documentation
 			throw new IOException(res);
 		} else {
 			throw new IOException(res);

--- a/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
+++ b/alfviral-platform/src/main/java/com/fegorsoft/alfresco/security/antivirus/InStreamScan.java
@@ -187,16 +187,19 @@ public final class InStreamScan implements VirusScanMode {
 		}
 
 		res = res.trim();
-		if (res.startsWith("INSTREAM size limit exceeded")) {
-			throw new IOException(res);
-		}
 
 		/*
 		 * if is OK then not infected, else, infected...
 		 */
-		if (!res.equals("stream: OK")) {
+		if (res.equals("stream: OK")) {
+			result = 0;
+		} else if (res.endsWith("FOUND")) {
 			result = 1;
 			addAspect();
+		} else if (res.endsWith("ERROR")) {
+			throw new IOException(res);
+		} else {
+			throw new IOException(res);
 		}
 
 		return result;


### PR DESCRIPTION
The way the scan result is handled leads to many possible false positives, when the result equals any kind of error message. This doesn't indicate the file is clean or infected, but rather that the scan did not complete.

[ALFREDOPS-833](https://xenitsupport.jira.com/browse/ALFREDOPS-833)